### PR TITLE
Add README.md and Neovim plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# kube.nvim
+
+kube.nvim is a Neovim plugin that provides an interface for managing Kubernetes resources directly from your editor. It allows you to view logs, forward ports, and manage resources without leaving Neovim.
+
+## Installation
+
+To install kube.nvim, use the LazyVim plugin manager. Add the following to your `lazy.lua` configuration file:
+
+```lua
+{
+  "kezhenxu94/kube.nvim",
+  config = function()
+    require("kube").setup()
+  end,
+}
+```
+
+Then, run `:Lazy sync` to install the plugin.
+
+## Usage
+
+To use kube.nvim, you can run the following commands in Neovim:
+
+- `:KubeGet <resource>`: Get a list of resources of the specified type.
+- `:KubeDelete <resource> <name>`: Delete the specified resource.
+- `:KubeContext <context>`: Switch to the specified Kubernetes context.
+
+## Features
+
+- **Resource Management**: Easily manage Kubernetes resources directly from Neovim.
+- **Log Viewing**: View logs for your Kubernetes resources.
+- **Port Forwarding**: Forward ports for your Kubernetes resources.
+
+## Contributing
+
+We welcome contributions to kube.nvim! If you would like to contribute, please follow these guidelines:
+
+1. Fork the repository and create a new branch for your changes.
+2. Make your changes and ensure that the code passes all tests.
+3. Submit a pull request with a description of your changes.
+
+If you encounter any issues or have any questions, please open an issue on the repository.
+
+## License
+
+kube.nvim is licensed under the MIT License. See the [LICENSE](LICENSE) file for more information.

--- a/doc/kube.txt
+++ b/doc/kube.txt
@@ -1,0 +1,52 @@
+* kube.txt*	For use with Neovim
+
+INTRODUCTION					*kube*
+
+kube.nvim is a Neovim plugin that provides an interface for managing Kubernetes resources directly from your editor. It allows you to view logs, forward ports, and manage resources without leaving Neovim.
+
+COMMANDS					*kube-commands*
+
+The following commands are available in kube.nvim:
+
+`:KubeGet <resource>`: Get a list of resources of the specified type.
+`:KubeDelete <resource> <name>`: Delete the specified resource.
+`:KubeContext <context>`: Switch to the specified Kubernetes context.
+
+KEY MAPPINGS					*kube-key-mappings*
+
+The following key mappings are available in kube.nvim:
+
+`<cr>`: Drill down into the resource under the cursor.
+`gl`: Show logs for the resource under the cursor.
+`gL`: Follow logs for the resource under the cursor.
+`gF`: Show port forwards for the resource under the cursor.
+`gf`: Forward ports for the resource under the cursor.
+`gy`: Show YAML for the resource under the cursor.
+`gd`: Describe the resource under the cursor.
+`ge`: Edit the resource under the cursor.
+`gi`: Set image for the resource under the cursor.
+`gr`: Refresh the resources in the buffer.
+
+CONFIGURATION					*kube-configuration*
+
+The following configuration options are available in kube.nvim:
+
+- `keymaps`: A table of key mappings. The default values are:
+  - `drill_down`: `<cr>`
+  - `describe`: `gd`
+  - `refresh`: `gr`
+  - `show_logs`: `gl`
+  - `follow_logs`: `gL`
+  - `port_forward`: `gF`
+  - `forward_port`: `gf`
+  - `show_yaml`: `gy`
+  - `edit`: `ge`
+  - `set_image`: `gi`
+- `highlights`: A table of highlight groups. The default values are:
+  - `KubeBody`: `{ fg = "#40a02b" }`
+  - `KubePending`: `{ fg = "#fe640b" }`
+  - `KubeRunning`: `{ fg = "#40a02b" }`
+  - `KubeFailed`: `{ fg = "#d20f39" }`
+  - `KubeSucceeded`: `{ fg = "#9ca0b0" }`
+  - `KubeUnknown`: `{ fg = "#6c6f85" }`
+  - `KubeHeader`: `{ fg = "#df8e1d", bold = true }`


### PR DESCRIPTION
Add detailed README.md and Neovim plugin documentation.

* **README.md**:
  - Create a new `README.md` file with a detailed description of the project.
  - Add installation instructions using the LazyVim plugin manager.
  - Include usage examples and a features section.
  - Add a section on how to contribute to the project.

* **doc/kube.txt**:
  - Create a new `doc/kube.txt` file with detailed Neovim plugin documentation.
  - Add a section describing the available commands and their usage.
  - Include a section on key mappings and their default values.
  - Add a section on configuration options and how to customize the plugin.

